### PR TITLE
Prevent pages from being indexed unless explicitly defined

### DIFF
--- a/src/Pages/Index.cshtml
+++ b/src/Pages/Index.cshtml
@@ -5,6 +5,11 @@
 @using Duende.IdentityServer.Models
 @model IdentityServerHost.Pages.Home.Index
 
+@section robots
+{
+    <meta name="robots" content="index, follow, archive" />
+}
+
 <div class="welcome-page">
     <h1>
         <img src="~/duende-logo.svg" class="logo">

--- a/src/Pages/Shared/_Layout.cshtml
+++ b/src/Pages/Shared/_Layout.cshtml
@@ -13,6 +13,15 @@
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/lib/bootstrap4-glyphicons/css/bootstrap-glyphicons.min.css" />
     <link rel="stylesheet" href="~/css/site.css" />
+
+    @if (IsSectionDefined("robots"))
+    {
+        @await RenderSectionAsync("robots")
+    }
+    else
+    {
+        <meta name="robots" content="noindex" />
+    }
 </head>
 <body>
     <partial name="_Nav" />


### PR DESCRIPTION
Make sure only root page gets indexed, no need for Google to do all kinds of redirect loops