### PR TITLE
Rename login client to interactive.implicit

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -404,6 +404,19 @@ namespace Duende.IdentityServer.Demo
                 // oidc login only
                 new Client
                 {
+                    ClientId = "interactive.implicit",
+
+                    RedirectUris = { "https://notused" },
+                    PostLogoutRedirectUris = { "https://notused" },
+
+                    AllowedGrantTypes = GrantTypes.Implicit,
+                    AllowedScopes = AllIdentityScopes,
+                },
+
+                // oidc login only - legacy client name. Keep until end of 2026
+                // to not break existing demos.
+                new Client
+                {
                     ClientId = "login",
                     
                     RedirectUris = { "https://notused" },

--- a/src/Pages/Index.cshtml
+++ b/src/Pages/Index.cshtml
@@ -168,7 +168,11 @@
     </p>
 
     <div id="accordion" class="mb-3">
-        @foreach (var clients in Config.Clients.GroupBy(it => it.ClientId.Split('.', StringSplitOptions.TrimEntries).First()))
+        @* 
+            We have a legacy login client that has been used in various demos. It's now renamed to interactive.implicit, but we need to have the
+            old entry around for some time, but don't want to show it any more. The login client and the .Where(g => g.Key != "login") can be removed after 2026.
+        *@
+        @foreach (var clients in Config.Clients.GroupBy(it => it.ClientId.Split('.', StringSplitOptions.TrimEntries).First()).Where(g => g.Key != "login"))
         {
             <div class="card mb-2">
                 <div id="clientid-@clients.Key" class="card-header bg-light shadow-sm border-0">


### PR DESCRIPTION
- Follow naming schemes, which moves the login to the right grouping on the start page.
- Keep the old client id around for some time to not break existing demos