### PR TITLE
JWT Decoder fixes

### DIFF
--- a/src/Pages/Home/JwtDecoder/JwtDecoder.cshtml
+++ b/src/Pages/Home/JwtDecoder/JwtDecoder.cshtml
@@ -1,4 +1,4 @@
-﻿@page "~/jwt-decoder"
+@page "~/jwt-decoder"
 @model IdentityServerHost.Pages.Home.JwtDecoder
 
 <div class="jwt-decoder-page">
@@ -335,7 +335,7 @@
             let debounceTimeout;
             jwtInput.on('input', function() {
                 clearTimeout(debounceTimeout);
-                debounceTimeout = setTimeout(async () => await parseJwt.call(this), 300); // 300ms debounce
+                debounceTimeout = setTimeout(async () => await parseJwt.call(this), 100); // 100ms debounce
             });
 
             @if (Model.View?.Token != null)

--- a/src/Pages/Home/JwtDecoder/JwtDecoder.cshtml
+++ b/src/Pages/Home/JwtDecoder/JwtDecoder.cshtml
@@ -373,10 +373,10 @@
                         encodedPayload: payloadInfo.length > 1 ? payloadInfo[1] : '',
                         signature: signature
                     };
-                    
-                    await showDecodedJwt(decodedJwt.header, decodedJwt.payload, decodedJwt.encodedHeader, decodedJwt.encodedPayload, signature);
+
                     colorJwtInput($(this), parts, decodedJwt.encodedHeader, decodedJwt.encodedPayload, decodedJwt.signature);
-                    
+                    await showDecodedJwt(decodedJwt.header, decodedJwt.payload, decodedJwt.encodedHeader, decodedJwt.encodedPayload, signature);
+                                        
                     if (parts.length !== 3) {
                         showError('Invalid JWT format. A JWT should have three parts separated by dots.');
                     }

--- a/src/Pages/Home/JwtDecoder/JwtDecoder.cshtml
+++ b/src/Pages/Home/JwtDecoder/JwtDecoder.cshtml
@@ -1,4 +1,4 @@
-@page "~/jwt-decoder"
+﻿@page "~/jwt-decoder"
 @model IdentityServerHost.Pages.Home.JwtDecoder
 
 <div class="jwt-decoder-page">
@@ -456,10 +456,16 @@
                     }
                 }
             }
+            else if (originalParts.length > 1) {
+                html += `<span class="skipped">${originalParts[0]}</span>`;
+            }
+
+            html += '<span class="jwt-divider">.</span>';
+            
             if (encodedPayload) {
                 const originalPayload = originalParts[1];
                 if (originalPayload === encodedPayload) {
-                    html += '<span class="jwt-divider">.</span>' + `<span class="text-success">${encodedPayload}</span>`;
+                    html += `<span class="text-success">${encodedPayload}</span>`;
                 }
                 else {
                     // Show the additional characters before and after the "encodedPayload" part that are found in originalPayload
@@ -468,14 +474,20 @@
                     if (start > 0) {
                         html += `<span class="skipped">${originalPayload.substring(0, start)}</span>`;
                     }
-                    html += '<span class="jwt-divider">.</span>' + `<span class="text-success">${encodedPayload}</span>`;
+                    html += `<span class="text-success">${encodedPayload}</span>`;
                     if (end < originalPayload.length) {
                         html += `<span class="skipped">${originalPayload.substring(end)}</span>`;
                     }
                 }
             }
+            else if (originalParts.length > 2) {
+                html += `<span class="skipped">${originalParts[1]}</span>`;
+            }
+
+            html += '<span class="jwt-divider">.</span>';
+            
             if (signature) {
-                html += '<span class="jwt-divider">.</span>' + `<span class="text-warning">${signature}</span>`;
+                html += `<span class="text-warning">${signature}</span>`;
             }
             target.html(html);
         }


### PR DESCRIPTION
* decreased the debounce time from 300 to 100ms
* moved input color matching before the parsing and signature validation logic to speed up showing visual feedback
* if the header or payload couldn't be parsed at all, it was being removed entirely from the input. No more, now it will be completely shown as invalid in the input box
* the '.' JWT separator was not being placed properly while coloring the input box