### PR TITLE
fix: Render device code collection UI if `userCode` query param is missing

### DIFF
--- a/src/Pages/Device/Index.cshtml
+++ b/src/Pages/Device/Index.cshtml
@@ -3,7 +3,7 @@
 @{
 }
 
-@if (Model.Input.UserCode == null)
+@if (Model.Input?.UserCode == null)
 {
     @*We need to collect the user code*@
     <div class="page-device-code">


### PR DESCRIPTION
This PR fixes the validation logic of `/Device/Index` (`GET`) to render user code collection UI if no `userCode` query parameter was specified. 
