### PR TITLE
Add IndexNow API key for site indexing

### DIFF
--- a/src/wwwroot/f8830c36ec8046eaaeb9c4a87adb0720.txt
+++ b/src/wwwroot/f8830c36ec8046eaaeb9c4a87adb0720.txt
@@ -1,0 +1,1 @@
+f8830c36ec8046eaaeb9c4a87adb0720


### PR DESCRIPTION

Added support for generating and setting an IndexNow API key to enable quicker indexing of website content.
